### PR TITLE
Replace deprecated add_object_page functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Turning Hello Dolly into a Freemium WordPress plugin.
 
 ## Folders Structure
 - *original*: The original Hello Dolly plugin written by Matt Mullenweg.
-- *extended*: Extended plugin version that adds 3 extra song lyrics by Louse Armstrong.
+- *extended*: Extended plugin version that adds 3 extra song lyrics by Louis Armstrong.
 - *freemium v.1*: Freemium version of the extended plugin powered by Freemius. Each song is only available in the corresponding plan.
 - *freemium v.2*: Another freemium version of the extended plugin. Instead of not showing the songs if the user don't have the required license, all the songs are shown in the settings but they are disabled and incetivize the user to upgrade.

--- a/extended/hello-dolly/hello.php
+++ b/extended/hello-dolly/hello.php
@@ -16,7 +16,7 @@
 	 * Adds simple menu item + settings page to admin dashboard.
 	 */
 	function hello_dolly_admin_menu() {
-		add_object_page(
+		add_menu_page(
 			__('Hello Dolly', 'hello-dolly'),
 			__('Hello Dolly', 'hello-dolly'),
 			'manage_options',

--- a/freemium v.1/hello-dolly/freemius/includes/class-freemius.php
+++ b/freemium v.1/hello-dolly/freemius/includes/class-freemius.php
@@ -373,7 +373,7 @@
 		{
 			self::$_static_logger->entrance();
 
-			$hook = add_object_page(
+			$hook = add_menu_page(
 				__('Freemius Debug', WP_FS__SLUG),
 				__('Freemius Debug', WP_FS__SLUG),
 				'manage_options',

--- a/freemium v.1/hello-dolly/hello.php
+++ b/freemium v.1/hello-dolly/hello.php
@@ -41,7 +41,7 @@
 	 * Adds simple menu item + settings page to admin dashboard.
 	 */
 	function hello_dolly_admin_menu() {
-		add_object_page(
+		add_menu_page(
 			__('Hello Dolly', 'hello-dolly'),
 			__('Hello Dolly', 'hello-dolly'),
 			'manage_options',

--- a/freemium v.2/hello-dolly/freemius/includes/class-freemius.php
+++ b/freemium v.2/hello-dolly/freemius/includes/class-freemius.php
@@ -373,7 +373,7 @@
 		{
 			self::$_static_logger->entrance();
 
-			$hook = add_object_page(
+			$hook = add_menu_page(
 				__('Freemius Debug', WP_FS__SLUG),
 				__('Freemius Debug', WP_FS__SLUG),
 				'manage_options',

--- a/freemium v.2/hello-dolly/hello.php
+++ b/freemium v.2/hello-dolly/hello.php
@@ -40,7 +40,7 @@
 	 * Adds simple menu item + settings page to admin dashboard.
 	 */
 	function hello_dolly_admin_menu() {
-		add_object_page(
+		add_menu_page(
 			__('Hello Dolly', 'hello-dolly'),
 			__('Hello Dolly', 'hello-dolly'),
 			'manage_options',


### PR DESCRIPTION
This replaces deprecated `add_object_page` with `add_menu_page'. The add_object_page function was deprecated in WP 4.5.